### PR TITLE
Implemented Global and User Header-based Limiting

### DIFF
--- a/k8s/istio.yml
+++ b/k8s/istio.yml
@@ -69,23 +69,51 @@ spec:
       # do this before every request to the gateway
       operation: INSERT_BEFORE
       value:
-        name: envoy.filters.http.local_ratelimit
+        name: envoy.filters.http.ratelimit
         typed_config:
-          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-          type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
-          value:
-            stat_prefix: http_local_rate_limiter
-            # each minute user gets 10 requests, reset every minute
-            token_bucket:
-              max_tokens: 10
-              tokens_per_fill: 10
-              fill_interval: 60s
-            # rate limit 100% of requests for now
-            filter_enabled:
-              default_value:
-                numerator: 100
-                denominator: HUNDRED
-            filter_enforced:
-              default_value:
-                numerator: 100
-                denominator: HUNDRED
+          "@type": type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit
+          domain: ratelimit
+          failure_mode_deny: true
+          timeout: 10s
+          rate_limit_service:
+            grpc_service:
+              envoy_grpc:
+                cluster_name: outbound|8081||ratelimit.istio-system.svc.cluster.local
+                authority: ratelimit.istio-system.svc.cluster.local
+            transport_api_version: V3
+  - applyTo: VIRTUAL_HOST
+    match:
+      context: GATEWAY
+      routeConfiguration:
+        vhost:
+          name: ""
+          route:
+            action: ANY
+    patch:
+      operation: MERGE
+      # Rate Limit Rules
+      value:
+        rate_limits:
+          - actions:
+            - request_headers:
+                header_name: "X-Access-User"
+                descriptor_key: "user"
+          - actions:
+            - generic_key:
+                descriptor_value: "all"
+          # value:
+          #   stat_prefix: http_local_rate_limiter
+          #   # each minute user gets 10 requests, reset every minute
+          #   token_bucket:
+          #     max_tokens: 10
+          #     tokens_per_fill: 10
+          #     fill_interval: 60s
+          #   # rate limit 100% of requests for now
+          #   filter_enabled:
+          #     default_value:
+          #       numerator: 100
+          #       denominator: HUNDRED
+          #   filter_enforced:
+          #     default_value:
+          #       numerator: 100
+          #       denominator: HUNDRED

--- a/k8s/rate-limit-config.yml
+++ b/k8s/rate-limit-config.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ratelimit-config
+  namespace: istio-system
+data:
+  config.yaml: |
+    domain: ratelimit
+    descriptors:
+      - key: user
+        rate_limit:
+          unit: minute
+          requests_per_unit: 10
+      
+      - key: generic_key
+        value: all
+        rate_limit:
+          unit: minute
+          requests_per_unit: 10

--- a/k8s/rate-limit-service.yml
+++ b/k8s/rate-limit-service.yml
@@ -1,0 +1,118 @@
+# credit: https://istio.io/latest/docs/tasks/policy-enforcement/rate-limit/#global-rate-limit
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: istio-system
+  labels:
+    app: redis
+spec:
+  ports:
+  - name: redis
+    port: 6379
+  selector:
+    app: redis
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: istio-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - image: docker.io/redis:alpine
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - name: redis
+          containerPort: 6379
+      restartPolicy: Always
+      serviceAccountName: ""
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ratelimit
+  namespace: istio-system
+  labels:
+    app: ratelimit
+spec:
+  ports:
+  - name: http-port
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+  - name: grpc-port
+    port: 8081
+    targetPort: 8081
+    protocol: TCP
+  - name: http-debug
+    port: 6070
+    targetPort: 6070
+    protocol: TCP
+  selector:
+    app: ratelimit
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ratelimit
+  namespace: istio-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ratelimit
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: ratelimit
+    spec:
+      containers:
+      - image: docker.io/envoyproxy/ratelimit:30a4ce1a # 2024/08/01
+        imagePullPolicy: IfNotPresent
+        name: ratelimit
+        command: ["/bin/ratelimit"]
+        env:
+        - name: LOG_LEVEL
+          value: debug
+        - name: REDIS_SOCKET_TYPE
+          value: tcp
+        - name: REDIS_URL
+          value: redis:6379
+        - name: USE_STATSD
+          value: "false"
+        - name: RUNTIME_ROOT
+          value: /data
+        - name: RUNTIME_SUBDIRECTORY
+          value: ratelimit
+        - name: RUNTIME_WATCH_ROOT
+          value: "false"
+        - name: RUNTIME_IGNOREDOTFILES
+          value: "true"
+        - name: HOST
+          value: "::"
+        - name: GRPC_HOST
+          value: "::"
+        ports:
+        - containerPort: 8080
+        - containerPort: 8081
+        - containerPort: 6070
+        volumeMounts:
+        - name: config-volume
+          mountPath: /data/ratelimit/config
+      volumes:
+      - name: config-volume
+        configMap:
+          name: ratelimit-config


### PR DESCRIPTION
Basically followed the docs for how to implement this:
https://istio.io/latest/docs/tasks/policy-enforcement/rate-limit/#global-rate-limit

Verification:
1. apply the k8s normally
2. portforward via:`kubectl -n istio-system port-forward svc/istio-ingressgateway 8080:80`
3. visit http://127.0.0.1:8080/ 
4. hit refresh 10+ times and it should block you

also implemented user-based blocking via headers!
you can try testing via:
```
URL="http://127.0.0.1:8080/"
for i in $(seq 1 20); do
  printf "%02d " "$i"
  curl -s -o /dev/null -w "%{http_code}\n" -H "X-Access-User: user1" "$URL"
done
```
this only works if request is sent using the header `X-Access-User`, will probably need to modify this for later.

you will notice 200 (success) for 10 times and then 429 on the 11th - 20th. 
after 1 minute it should unblock you.
